### PR TITLE
Change recipe show so ingredients no longer have to be comma separated

### DIFF
--- a/app/views/recipes/show.html.haml
+++ b/app/views/recipes/show.html.haml
@@ -28,7 +28,7 @@
 			.col-md-2
 			.col-md-8.pull-right
 				%p
-					- @recipe.ingredients.split(",").each do |ingred|
+					- @recipe.ingredients.split("\n").each do |ingred|
 						%li= ingred.downcase
 			.col-md-2
 		.col-md-6.col-sm.12


### PR DESCRIPTION
This was a lot easier than I thought. I don't know why I didn't do this in the first place.
